### PR TITLE
Users should get stats of trips made in the last X timeframe

### DIFF
--- a/src/controllers/requestController.js
+++ b/src/controllers/requestController.js
@@ -3,7 +3,7 @@ import { Helpers, ApiError } from '../utils';
 
 const {
   getRequests, getRequest, updateAnyRequest,
-  getRequestByIdUserId, createTripRequest
+  getRequestByIdUserId, createTripRequest, searchByTime
 } = RequestService;
 
 const { successResponse, errorResponse } = Helpers;
@@ -36,13 +36,32 @@ export default class RequestController {
   }
 
   /**
-  *  creates a one way trip request
-  * @static
-  * @param {Request} req - The request from the endpoint.
-  * @param {Response} res - The response returned by the method.
-  * @returns { JSON } - A JSON object containing success or failure details.
-  * @memberof RequestController
-  */
+*  Gets trip request stats within a timeframe
+* @static
+* @param {Request} req - The request from the endpoint.
+* @param {Response} res - The response returned by the method.
+* @returns { JSON } - A JSON object containing success or failure details.
+* @memberof RequestController
+*/
+  static async getTripRequestsStats(req, res) {
+    try {
+      const { start: startDate, end: endDate } = req.query;
+      const { id } = req.data;
+      const result = await searchByTime(startDate, endDate, id);
+      return successResponse(res, result, 200);
+    } catch (err) {
+      errorResponse(res, { code: 500, message: err.message });
+    }
+  }
+
+  /**
+   *  creates a one way trip request
+   * @static
+   * @param {Request} req - The request from the endpoint.
+   * @param {Response} res - The response returned by the method.
+   * @returns { JSON } - A JSON object containing success or failure details.
+   * @memberof RequestController
+   */
   static async oneWayTripRequest(req, res) {
     try {
       const { body } = req;

--- a/src/middlewares/tripRequestMiddleware.js
+++ b/src/middlewares/tripRequestMiddleware.js
@@ -3,7 +3,7 @@ import { Helpers, ApiError } from '../utils';
 import { UserService } from '../services';
 
 const { errorResponse } = Helpers;
-const { tripRequest } = TripRequestValidation;
+const { tripRequest, statsRequest } = TripRequestValidation;
 const { find } = UserService;
 
 /**
@@ -71,6 +71,23 @@ export default class TripRequestMiddleware {
       tripUserChecker('Line Manager', requesterLineManager);
       tripUserChecker('PassportNo', requesterPassportNo);
       next();
+    } catch (error) {
+      errorResponse(res, { code: error.status || 500, message: error.message });
+    }
+  }
+
+  /**
+       * Middleware method for trip stats request validation
+       * @param {object} req - The request from the endpoint.
+       * @param {object} res - The response returned by the method.
+       * @param {object} next - Call the next operation.
+       * @returns {object} - Returns an object (error or response).
+       */
+  static async tripStatsCheck(req, res, next) {
+    try {
+      const { start: startDate, end: endDate } = req.query;
+      const validated = statsRequest({ startDate, endDate });
+      if (validated) next();
     } catch (error) {
       errorResponse(res, { code: error.status || 500, message: error.message });
     }

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -2,25 +2,25 @@ import { Router } from 'express';
 import { Permissions } from '../utils';
 import { UserController, RoleController, RequestController } from '../controllers';
 import {
-  AuthMiddleware, RoleMiddleware, UserMiddleware, RequestMiddleware
+  AuthMiddleware, RoleMiddleware, UserMiddleware, RequestMiddleware, TripRequestMiddleware
 } from '../middlewares';
-
-const { verifyRoles } = RoleMiddleware;
-const { supplierAdmin, companyAdminManager } = Permissions;
 
 const router = Router();
 
+const { verifyRoles } = RoleMiddleware;
+const { supplierAdmin, companyAdminManager } = Permissions;
 const { updateUserRole } = RoleController;
 const {
   userProfile, updateProfile
 } = UserController;
 const {
   getRequest, updateRequest, getUserRequests,
-  getRequestByIdUserId, updateUserRequest
+  getRequestByIdUserId, updateUserRequest, getTripRequestsStats
 } = RequestController;
 const { isAuthenticated, authenticate } = AuthMiddleware;
 const { onUpdateProfile } = UserMiddleware;
 const { onRequestStatus, isUsersOwnIsStatus } = RequestMiddleware;
+const { tripStatsCheck } = TripRequestMiddleware;
 
 router.get('/profile/:userId', authenticate, isAuthenticated, userProfile);
 router.put('/profile/:userId', authenticate, isAuthenticated, onUpdateProfile, updateProfile);
@@ -30,6 +30,7 @@ router.get('/requests/:statusId', authenticate, verifyRoles(companyAdminManager)
 router.patch('/requests/:requestId', authenticate, verifyRoles(companyAdminManager), onRequestStatus, updateRequest); // update requests by specifying request id in params
 router.get('/requests/:requestId/edit', authenticate, isUsersOwnIsStatus, onRequestStatus, getRequestByIdUserId);// get a single request by userId and requestId
 router.put('/requests/:requestId/update', authenticate, isUsersOwnIsStatus, onRequestStatus, updateUserRequest);
+router.get('/request/stats', authenticate, tripStatsCheck, getTripRequestsStats);
 
 router.patch('/role', authenticate, verifyRoles(supplierAdmin), updateUserRole);
 

--- a/src/services/requestService.js
+++ b/src/services/requestService.js
@@ -1,3 +1,4 @@
+import { Op } from 'sequelize';
 import db from '../models';
 import { ApiError } from '../utils';
 import RoomService from './roomService';
@@ -173,5 +174,26 @@ export default class RequestService {
    */
   static async findRequestById(requestId, options = {}) {
     return Request.findByPk(requestId, options);
+  }
+
+  /**
+   * Fetches a request instance from the database based on it's primary key within a timeframe.
+   * @static
+   * @param {sting} startDate - Request start date
+   * @param {sting} endDate - Request end date
+   * @param {integer} userId - Primary key of the request to be fetched.
+   * @returns {Promise<string>} - Number of counts.
+   * @memberof FacilityService
+   */
+  static async searchByTime(startDate, endDate, userId) {
+    const request = await Request.findAndCountAll({
+      where: {
+        createdAt: {
+          [Op.between]: [startDate, endDate]
+        },
+        requesterId: userId
+      }
+    });
+    return request.count;
   }
 }

--- a/src/test/dummies.js
+++ b/src/test/dummies.js
@@ -151,3 +151,15 @@ export const newNotification = {
   message: 'A new user was created',
   url: 'lormipsu.com',
 };
+
+export const formatDate = (date) => {
+  const d = new Date(date),
+    year = d.getFullYear();
+  let month = `${d.getMonth() + 1}`,
+    day = `${d.getDate()}`;
+
+  if (month.length < 2) { month = `0${month}`; }
+  if (day.length < 2) { day = `0${day}`; }
+
+  return [year, month, day].join('-');
+};

--- a/src/test/user.test.js
+++ b/src/test/user.test.js
@@ -92,7 +92,7 @@ describe('GET /users/requests', () => {
 describe('POST /users/request/stats', () => {
   it('should successfully return the number of trip request count', async () => {
     const queryObj = {
-      startDate: formatDate(Date.now()),
+      startDate: '2019-09-16',
       endDate: formatDate(Date.now())
     };
     const response = await chai.request(server)
@@ -102,6 +102,19 @@ describe('POST /users/request/stats', () => {
     expect(response).to.have.status(200);
     expect(status).to.equal('success');
     expect(data).to.be.a('number');
+  });
+  it('should return an error of 400 for endDate less than startDate', async () => {
+    const queryObj = {
+      startDate: '2019-09-16',
+      endDate: '2019-09-15'
+    };
+    const response = await chai.request(server)
+      .get(`/api/users/request/stats?start=${queryObj.startDate}&end=${queryObj.endDate}`)
+      .set('Cookie', `token=${token}`);
+    const { body: { status, error } } = response;
+    expect(response).to.have.status(400);
+    expect(status).to.equal('fail');
+    expect(error.message).to.be.a('string');
   });
   it('should return 400 error for invalid date input', async () => {
     const queryObj = {

--- a/src/test/user.test.js
+++ b/src/test/user.test.js
@@ -2,6 +2,7 @@ import chai, { expect } from 'chai';
 import faker from 'faker';
 import chaiHttp from 'chai-http';
 import server from '../index';
+import { formatDate } from './dummies';
 
 chai.use(chaiHttp);
 let newlyCreatedUser;
@@ -85,5 +86,34 @@ describe('GET /users/requests', () => {
   it('should return 404 for user with no request yet', async () => {
     const response = await chai.request(server).get('/api/users/requests').set('Cookie', `token=${token}`);
     expect(response).to.have.status(404);
+  });
+});
+
+describe('POST /users/request/stats', () => {
+  it('should successfully return the number of trip request count', async () => {
+    const queryObj = {
+      startDate: formatDate(Date.now()),
+      endDate: formatDate(Date.now())
+    };
+    const response = await chai.request(server)
+      .get(`/api/users/request/stats?start=${queryObj.startDate}&end=${queryObj.endDate}`)
+      .set('Cookie', `token=${token}`);
+    const { body: { status, data } } = response;
+    expect(response).to.have.status(200);
+    expect(status).to.equal('success');
+    expect(data).to.be.a('number');
+  });
+  it('should return 400 error for invalid date input', async () => {
+    const queryObj = {
+      startDate: formatDate(Date.now()),
+      endDate: '2019-09'
+    };
+    const response = await chai.request(server)
+      .get(`/api/users/request/stats?start=${queryObj.startDate}&end=${queryObj.endDate}`)
+      .set('Cookie', `token=${token}`);
+    const { body: { status, error } } = response;
+    expect(response).to.have.status(400);
+    expect(status).to.equal('fail');
+    expect(error.message).to.be.a('string');
   });
 });

--- a/src/validation/tripRequestValidation.js
+++ b/src/validation/tripRequestValidation.js
@@ -148,6 +148,32 @@ export default class TripRequestValidation {
   }
 
   /**
+  * Validates Trip stats Request paramenters
+  *
+  * @param {object} body - The request object
+  * @param {object} res - The request response object
+  * @returns {object} - returns an object (error or response).
+  */
+  static statsRequest(body) {
+    const schema = {
+      startDate: Joi.date()
+        .format('YYYY-MM-DD')
+        .required()
+        .error(TripRequestValidation.validateTripStats('startDate')),
+      endDate: Joi.date()
+        .format('YYYY-MM-DD')
+        .min(body.startDate)
+        .required()
+        .error(TripRequestValidation.validateTripStats('endDate'))
+    };
+    const { error } = Joi.validate({ ...body }, schema);
+    if (error) {
+      throw new ApiError(400, error.details[0].message);
+    }
+    return true;
+  }
+
+  /**
    * Validates departureDate and returnDate keys
    * @param {string} key - The key to validate
    * @returns {Error} Returns a descriptive error message
@@ -167,6 +193,35 @@ export default class TripRequestValidation {
             break;
           case 'date.min':
             err.message = `${key} must be larger than or equal to ${key === 'departureDate' ? 'today' : 'departureDate'}`;
+            break;
+          default:
+            break;
+        }
+      });
+      return errors;
+    };
+  }
+
+  /**
+   * Validates trip request stats keys
+   * @param {string} key - The key to validate
+   * @returns {Error} Returns a descriptive error message
+   */
+  static validateTripStats(key) {
+    return (errors) => {
+      errors.forEach((err) => {
+        switch (err.type) {
+          case 'any.required':
+            err.message = `${key} is required!`;
+            break;
+          case 'date.format':
+            err.message = `${key} should be in this format ${err.context.format}`;
+            break;
+          case 'date.base':
+            err.message = `${key} should not be empty`;
+            break;
+          case 'date.min':
+            err.message = `${key} must be larger than or equal to ${key === 'startDate' ? 'today' : 'startDate'}`;
             break;
           default:
             break;

--- a/swagger.json
+++ b/swagger.json
@@ -596,6 +596,61 @@
                 }
             }
         },
+        "/users/request/stats?start={startDate}&end={endDate}": {
+            "get": {
+                "description": "Get all requests for a particular user within timeframe",
+                "summary": "User can get their request history within a timeframe",
+                "tags": [
+                    "Users"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "startDate",
+                        "required": true,
+                        "schema": {
+                            "type":"string",
+                            "format": "date",
+                            "default": "2019-09-16"
+                        },
+                        "description": "Start date of the request"
+                    },
+                    {
+                        "in": "path",
+                        "name": "endDate",
+                        "required": true,
+                        "schema": {
+                            "type":"string",
+                            "format": "date",
+                            "default": "2019-09-20"
+                        },
+                        "description": "End date of the request"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Access denied, Token required"
+                    },
+                    "404": {
+                        "description": "You have not made any request yet"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
         "/users/role": {
             "patch": {
                 "description": "Updates User Role",
@@ -774,7 +829,7 @@
                         "in": "path",
                         "name": "facilityId",
                         "required": true,
-                        "description": "TThe id of facility to be updated"
+                        "description": "The id of facility to be updated"
                     },
                     {
                         "in": "path",


### PR DESCRIPTION
#### What does this PR do?
Enables managers and to get detailed statistics of the number of trips they made within a specified timeframe e.g month, week
#### Description of Task to be completed?
- Create a controller method to handle trip request stats
- Implement the service method for searching request db.
- Implement the endpoint for trip request stats.
- Write unit tests for the functionalities
- Document feature
#### How should this be manually tested?
- Clone the repo and cd into the project folder
- Update or copy `.env` file from `.env.sample`
- Checkout to `ft-trips-stats-by-users-167733679` branch and run `npm install`
- - Run `npm run migrate:reset` && `npm run migrate` && `npm run seed` to create tables in your 
 database and seed the database tables with the necessary app configs.
- Run `docker-compose up --build` to build the docker image and spin up all the necessary services
- As an alternative to running the app on docker, you can run `npm run start:dev`
- Launch [http://localhost:3000/api/users/request/stats?start=2019-09-16&end=2019-09-17](http://localhost:3000/api/users/request/stats?start=2019-09-16&end=2019-09-17) on Postman, check image below
![image](https://user-images.githubusercontent.com/12023778/64995436-201d4900-d8d3-11e9-9b16-90610e485711.png)


#### What are the relevant pivotal tracker stories?
