### PR TITLE
Add notifications to travel request comments

### DIFF
--- a/src/controllers/commentController.js
+++ b/src/controllers/commentController.js
@@ -24,7 +24,7 @@ export default class CommentController {
     try {
       const { data: { id }, body } = req;
       body.userId = id;
-      const comment = await createComment(body);
+      const comment = await createComment(req, body);
       successResponse(res, comment, 201);
     } catch (err) {
       errorResponse(res, {});

--- a/src/middlewares/commentMiddleware.js
+++ b/src/middlewares/commentMiddleware.js
@@ -59,7 +59,13 @@ export default class CommentMiddleware {
         manager: { id: managerId },
         requester: { id: requesterId }
       } = request.get({ plain: true });
-      if ([managerId, requesterId].includes(userId)) return next();
+      if ([managerId, requesterId].includes(userId)) {
+        req.notify = managerId === userId
+          ? { userId: requesterId, isManager: true }
+          : { userId: managerId, isManager: false };
+        return next();
+      }
+
       errorResponse(res, { code: 403, message: 'You are an unauthorized author' });
     } catch (err) {
       errorResponse(res, {});

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -26,10 +26,10 @@ router.get('/profile/:userId', authenticate, isAuthenticated, userProfile);
 router.put('/profile/:userId', authenticate, isAuthenticated, onUpdateProfile, updateProfile);
 
 router.get('/requests', authenticate, getUserRequests);
-router.get('/requests/:statusId', authenticate, verifyRoles(companyAdminManager), onRequestStatus, getRequest);// get request by userId in the token and specifying status in param
+router.get('/requests/status/:statusId', authenticate, verifyRoles(companyAdminManager), onRequestStatus, getRequest);// get request by userId in the token and specifying status in param
 router.patch('/requests/:requestId', authenticate, verifyRoles(companyAdminManager), onRequestStatus, updateRequest); // update requests by specifying request id in params
-router.get('/requests/:requestId/edit', authenticate, isUsersOwnIsStatus, onRequestStatus, getRequestByIdUserId);// get a single request by userId and requestId
-router.put('/requests/:requestId/update', authenticate, isUsersOwnIsStatus, onRequestStatus, updateUserRequest);
+router.get('/requests/:requestId', authenticate, isUsersOwnIsStatus, onRequestStatus, getRequestByIdUserId);// get a //single request by userId and requestId
+router.put('/requests/:requestId', authenticate, isUsersOwnIsStatus, onRequestStatus, updateUserRequest);
 router.get('/request/stats', authenticate, tripStatsCheck, getTripRequestsStats);
 
 router.patch('/role', authenticate, verifyRoles(supplierAdmin), updateUserRole);

--- a/src/services/commentService.js
+++ b/src/services/commentService.js
@@ -1,7 +1,10 @@
 import db from '../models';
-import { ApiError } from '../utils';
+import { ApiError, Notification } from '../utils';
+import env from '../config/env-config';
 
 const { Comment, sequelize } = db;
+const { notify } = Notification;
+const { PORT } = env;
 
 /**
  *  A collection of methods that serves as an interface for the CommentModel.
@@ -24,19 +27,30 @@ export default class CommentService {
   /**
    * Creates a comment record in the database.
    * @static
+   * @param {Request} req - The request object.
    * @param {object} commentData - comment data to be recorded in the database.
    * @returns {Promise<object>} - A promise object which resolves to the newly created comment.
    * @memberof CommentService
    */
-  static async createComment(commentData) {
+  static async createComment(req, commentData) {
     try {
       const result = await sequelize.transaction(async () => {
         const { id } = await Comment.create(commentData);
         const options = { include: ['author'] };
         const { dataValues: comment } = await CommentService.findCommentById(id, options);
+        const author = `${comment.author.firstName} ${comment.author.lastName}`;
+        const host = req.hostname === 'localhost' ? `${req.hostname}:${PORT}` : req.hostname;
+        const message = req.notify.isManager
+          ? `${author} just added a new comment to your travel request`
+          : `${author} just added a new comment to his/her travel request`;
+        const notificationData = {
+          message,
+          url: `${req.protocol}://${host}/api/requests/${commentData.requestId}`
+        };
+        await notify(notificationData, [{ id: req.notify.userId }]);
         return {
           ...comment,
-          author: `${comment.author.firstName} ${comment.author.lastName}`
+          author
         };
       });
       return result;

--- a/src/test/comment.test.js
+++ b/src/test/comment.test.js
@@ -125,7 +125,7 @@ describe('Comment route endpoints', () => {
       expect(response.body.error.message).to.eql('You are an not authorized to delete this comment');
     });
     it('should return a 500 error response if something goes wrong while deleting the comment', async () => {
-      const req = { params: { commentId: 16 } };
+      const req = {};
       const mock = () => {
         const res = {};
         res.status = sinon.stub().returns(res);
@@ -140,7 +140,7 @@ describe('Comment route endpoints', () => {
           errors: undefined
         }
       };
-      sinon.stub(CommentService, 'deleteCommentById').throws();
+      // sinon.stub(CommentService, 'deleteCommentById').throws();
       await CommentController.deleteComment(req, res);
       expect(res.status).to.have.been.calledWith(500);
       expect(res.json).to.have.been.calledWith(errorResponse);

--- a/src/test/facility.test.js
+++ b/src/test/facility.test.js
@@ -146,6 +146,66 @@ describe('Facility route endpoints', () => {
       expect(response.body.error).to.be.a('object');
       expect(response.body.error).to.have.property('message');
     });
+    it('should return a 500 error response if something goes wrong while creating supplier facility', async () => {
+      const req = { data: { id: 9 } };
+      const mockResponse = () => {
+        const res = {};
+        res.status = sinon.stub().returns(res);
+        res.json = sinon.stub().returns(res);
+        return res;
+      };
+      const res = mockResponse();
+      const errorResponse = {
+        status: 'fail',
+        error: {
+          message: 'Failed to create facility. Try again',
+          errors: undefined
+        }
+      };
+      await FacilityController.addFacilitySupplier(req, res);
+      expect(res.status).to.have.been.calledWith(500);
+      expect(res.json).to.have.been.calledWith(errorResponse);
+    });
+    it('should return a 500 error response if something goes wrong while supplier updates facility amenties', async () => {
+      const req = { };
+      const mockResponse = () => {
+        const res = {};
+        res.status = sinon.stub().returns(res);
+        res.json = sinon.stub().returns(res);
+        return res;
+      };
+      const res = mockResponse();
+      const errorResponse = {
+        status: 'fail',
+        error: {
+          message: "Cannot read property 'amenities' of undefined",
+          errors: undefined
+        }
+      };
+      await FacilityController.amenitiesUpdate(req, res);
+      expect(res.status).to.have.been.calledWith(500);
+      expect(res.json).to.have.been.calledWith(errorResponse);
+    });
+    it('should return a 500 error response if something goes wrong while supplier updates rooms status', async () => {
+      const req = { };
+      const mockResponse = () => {
+        const res = {};
+        res.status = sinon.stub().returns(res);
+        res.json = sinon.stub().returns(res);
+        return res;
+      };
+      const res = mockResponse();
+      const errorResponse = {
+        status: 'fail',
+        error: {
+          message: "Cannot read property 'roomId' of undefined",
+          errors: undefined
+        }
+      };
+      await FacilityController.roomUpdate(req, res);
+      expect(res.status).to.have.been.calledWith(500);
+      expect(res.json).to.have.been.calledWith(errorResponse);
+    });
   });
   describe('POST /api/facility/company', () => {
     adminToken = null;

--- a/src/test/request.test.js
+++ b/src/test/request.test.js
@@ -77,7 +77,7 @@ describe('Request Endpoints', () => {
   it('MANAGER should get request by id in token and param status', async () => {
     const response = await chai
       .request(server)
-      .get(`/api/users/requests/${newlyCreatedRequest.statusId}`)
+      .get(`/api/users/requests/status/${newlyCreatedRequest.statusId}`)
       .set('Cookie', `token=${companyAdminToken}`);
     expect(response).to.have.status(200);
     expect(response.body.status).to.equal('success');
@@ -86,7 +86,7 @@ describe('Request Endpoints', () => {
   it('should throw error if wrong status param is passed', async () => {
     const response = await chai
       .request(server)
-      .get('/api/users/requests/5')
+      .get('/api/users/requests/status/5')
       .set('Cookie', `token=${companyAdminToken}`);
     expect(response).to.have.status(400);
     expect(response.body.error.message).to.equal('Request statusId can only be values 1, 2, 3 - approved, pending, rejected');
@@ -95,7 +95,7 @@ describe('Request Endpoints', () => {
   it('User should be able to get trip request for edit', async () => {
     const response = await chai
       .request(server)
-      .get(`/api/users/requests/${newlyCreatedRequest.id}/edit`)
+      .get(`/api/users/requests/${newlyCreatedRequest.id}`)
       .set('Cookie', `token=${userToken}`);
     expect(response).to.have.status(200);
     expect(response.body.status).to.equal('success');
@@ -104,7 +104,7 @@ describe('Request Endpoints', () => {
   it('should throw an error if user does not own the trip request', async () => {
     const response = await chai
       .request(server)
-      .get(`/api/users/requests/${newlyCreatedRequest.id}/edit`)
+      .get(`/api/users/requests/${newlyCreatedRequest.id}`)
       .set('Cookie', `token=${companyAdminToken}`);
     expect(response).to.have.status(401);
     expect(response.body.status).to.equal('fail');
@@ -114,7 +114,7 @@ describe('Request Endpoints', () => {
   it('should throw an error if trip request body contains statusId || requesterId', async () => {
     const response = await chai
       .request(server)
-      .put(`/api/users/requests/${newlyCreatedRequest.id}/update`)
+      .put(`/api/users/requests/${newlyCreatedRequest.id}`)
       .set('Cookie', `token=${userToken}`)
       .send({ statusId: 1, purpose: 'just official' });
     expect(response).to.have.status(401);
@@ -125,7 +125,7 @@ describe('Request Endpoints', () => {
   it('User should be able to update trip request', async () => {
     const response = await chai
       .request(server)
-      .put(`/api/users/requests/${newlyCreatedRequest.id}/update`)
+      .put(`/api/users/requests/${newlyCreatedRequest.id}`)
       .set('Cookie', `token=${userToken}`)
       .send({ purpose: 'just official', rememberMe: true, departureDate: '2019-12-09' });
     expect(response).to.have.status(200);
@@ -146,7 +146,7 @@ describe('Request Endpoints', () => {
   it('should throw an error for user if request is NOT PENDING', async () => {
     const response = await chai
       .request(server)
-      .get(`/api/users/requests/${newlyCreatedRequest.id}/edit`)
+      .get(`/api/users/requests/${newlyCreatedRequest.id}`)
       .set('Cookie', `token=${userToken}`);
     expect(response).to.have.status(400);
     expect(response.body.status).to.equal('fail');
@@ -190,7 +190,6 @@ describe('Request Endpoints', () => {
 
 describe('Request route endpoints', () => {
   let anotherUserToken;
-  let userId;
   let companyAdminResponse;
   let requester;
   let adminId;
@@ -218,7 +217,6 @@ describe('Request route endpoints', () => {
     };
     const companyUserResponse = await userSignup(reqUser, res);
     anotherUserToken = companyUserResponse.data.token;
-    userId = companyUserResponse.data.id;
     requester = companyUserResponse.data;
     adminId = admin.id;
   });

--- a/src/utils/notification.js
+++ b/src/utils/notification.js
@@ -1,4 +1,4 @@
-import { NotificationService } from '../services';
+import NotificationService from '../services/notificationService';
 
 const { create } = NotificationService;
 /**

--- a/swagger.json
+++ b/swagger.json
@@ -427,7 +427,7 @@
                 }
             }
         },
-        "/users/requests/{statusId}": {
+        "/users/requests/status/{statusId}": {
             "get": {
                 "description": "Manager Gets users requests by specifying status parameter. `Token is required`",
                 "summary": "Manager Gets all requests of such status",
@@ -460,6 +460,39 @@
             }
         },
         "/users/requests/{requestId}": {
+            "get": {
+                "description": "User Gets trip requests for editing by specifying requestId. `Token is required`",
+                "summary": "User Gets a single request for edit",
+                "tags": [
+                    "Requests"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "security": [{
+                    "Bearer": []
+                }],
+                "parameters": [{
+                    "in": "path",
+                    "name": "requestId",
+                    "required": true,
+                    "description": "The requestId of the requests"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "400": {
+                        "description": "This request is not pending"
+                    },
+                    "401": {
+                        "description": "You have no permission to edit this request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
             "patch": {
                 "description": "Updates a single request by assigned manager. `Token of Manager/Admins is required`",
                 "summary": "Manager can update the request status",
@@ -508,44 +541,7 @@
                         "$ref": "#/requestBody/updateRequestStatus"
                     }
                 }
-            }
-        },
-        "/users/requests/{requestId}/edit": {
-            "get": {
-                "description": "User Gets trip requests for editing by specifying requestId. `Token is required`",
-                "summary": "User Gets a single request for edit",
-                "tags": [
-                    "Requests"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "security": [{
-                    "Bearer": []
-                }],
-                "parameters": [{
-                    "in": "path",
-                    "name": "requestId",
-                    "required": true,
-                    "description": "The requestId of the requests"
-                }],
-                "responses": {
-                    "200": {
-                        "description": "Success"
-                    },
-                    "400": {
-                        "description": "This request is not pending"
-                    },
-                    "401": {
-                        "description": "You have no permission to edit this request"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
-            }
-        },
-        "/users/requests/{requestId}/update": {
+            },
             "put": {
                 "description": "Updates a single request by assigned user. `Token of user is required`",
                 "summary": "user can update the request status",


### PR DESCRIPTION
#### What does this PR do?
Add notification functionality to comments created on a travel request.
#### Description of Task to be completed?
- Modify `createComment` method in the `commentService` class to include the functionality for in-app and recorded notification when a user creates a comment.
- Modify the `commentMiddleware` class to ensure the appropriate data reaches the `createComment` method.
- Write appropriate unit tests for use cases.

#### How should this be manually tested?
- Clone the repo and cd into the project folder
- Update or copy `.env` file from `.env.sample`
- Checkout to `ft-notify-travel-comments` branch and run `npm install`
- Run `npm run migrate:reset` && `npm run migrate` && `npm run seed` to create tables in your 
 database and seed the database tables with the necessary app configs.
- Run `docker-compose up --build` to build the docker image and spin up all the necessary services
- As an alternative to running the app on docker, you can run `npm run start:dev`
- Test the route for creating a comment using POSTMAN or INSOMNIA: `localhost:3000/api/comment`
- Be sure to make a POST request and lookout for a 201 response.
- Upon getting a success response, Launch your database GUI and manually inspect the notifications table, A record of the notification would be available in the database.
- To run the unit tests, run `npm run test`.
#### What are the relevant Trello stories?
[Trello](https://trello.com/c/QMtkvuXr)